### PR TITLE
Recognize draft references in two-column title block

### DIFF
--- a/rfc2html.py
+++ b/rfc2html.py
@@ -192,7 +192,7 @@ def markup(text, path=".", script="", extra="", name=None):
   
         # draft markup
         # draft name crossing line break
-        text = re.sub("([^/#=\?\w-])(draft-([-a-zA-Z0-9]+-)?)(\n +)([-a-zA-Z0-9]+[a-zA-Z0-9](.txt)?)",
+        text = re.sub("([^/#=\?\w-])(draft-([-a-zA-Z0-9]+-)?)((?: {3,}\S.*)?\n +)([-a-zA-Z0-9]+[a-zA-Z0-9](.txt)?)",
                         "\g<1><a href=\"%s?%sdraft=\g<2>\g<5>\">\g<2></a>\g<4><a href=\"%s?%sdraft=\g<2>\g<5>\">\g<5></a>" % (script, extra, script, extra), text)
         # draft name on one line (but don't mess with what we just did above)
         text = re.sub("([^/#=\?\w>=-])(draft-[-a-zA-Z0-9]+[a-zA-Z0-9](.txt)?)",

--- a/tests.py
+++ b/tests.py
@@ -21,5 +21,22 @@ class MarkupTestCase(TestCase):
         html = markup('text RFC1234 text')
         self.assertEqual(html, '<pre>text <a href="./rfc1234">RFC1234</a> text</pre>')
 
+    def test_draft_ref_with_linebreak(self):
+        html = markup('draft-ietf-\n              some-name-00')
+        self.assertEqual(
+            html,
+            '<pre>{open_tag}draft-ietf-</a>\n              {open_tag}some-name-00</a></pre>'.format(
+                open_tag='<a href="./draft-ietf-some-name-00">',
+            ))
+
+    def test_draft_ref_with_linebreak_in_header(self):
+        html = markup('draft-ietf-   S. Author\n              some-name-00   Org')
+        self.assertEqual(
+            html,
+            '<pre>{open_tag}draft-ietf-</a>   S. Author\n              {open_tag}some-name-00</a>   Org</pre>'.format(
+                open_tag='<a href="./draft-ietf-some-name-00">',
+            ))
+
 if __name__ == '__main__':
+    import unittest
     unittest.main()


### PR DESCRIPTION
  * Adjust split-line draft name regex to allow text after 3+ spaces
  * Add test cases
  * Import unittest when running tests.py directly