### PR TITLE
fix: Use `h` tags for headings instead of classes.

### DIFF
--- a/rfc2html.py
+++ b/rfc2html.py
@@ -402,7 +402,7 @@ def markup(text, path=".", script="", extra="", name=None):
 
     #
     #text = re.sub("\f", "<div class=\"newpage\" />", text)
-    text = re.sub(r"\n?\f\n?", '\n', text)
+    text = re.sub(r"\n?\f\n?", '</pre>\n<pre class="newpage">', text)
 
     # restore indentation
     if prefixlen:


### PR DESCRIPTION
Fixes https://github.com/ietf-tools/datatracker/issues/3466

Also update the regex syntax for python3, to silence some ﻿﻿﻿﻿deprecation warnings on import.