### PR TITLE
feat: CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ with open('rfc3344.txt') as file:
 html = markup(text)
 ```
 
+This function can be used via the CLI:
+
+```bash
+$ rfc2html -v rfc3344.txt
+rfc3344.txt.html
+```
+
 ### History
 
 As a historic artifact of being a document series which was started at the time when the easiest

--- a/rfc2html.py
+++ b/rfc2html.py
@@ -5,6 +5,7 @@
 
 from __future__ import unicode_literals, print_function, division
 
+import argparse
 import re
 try:
     from html import escape
@@ -413,3 +414,22 @@ def markup(text, path=".", script="", extra="", name=None):
         text = re.sub(r"%s\?draft=" % script, r"%s/" % path, text)
 
     return text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert RFC .txt files to .html ones.")
+    parser.add_argument("files", nargs="+", metavar="FILE", help="text file to htmlize")
+    parser.add_argument("-v", "--verbose", action="store_true", help="name the html files as they are created")
+    options = parser.parse_args()
+
+    for filename_txt in options.files:
+        filename_html = filename_txt + ".html"
+        with open(filename_txt) as file_txt:
+            with open(filename_html, "w") as file_html:
+                file_html.write(markup(file_txt.read()))
+        if options.verbose:
+            print(filename_html)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,11 @@ setup(
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.
-    #entry_points={},
+    entry_points={
+        "console_scripts": [
+            "rfc2html = rfc2html:main",
+        ],
+    },
 
 
     # We're reading schema files from a package directory.


### PR DESCRIPTION
This adds a script entrypoint to run the markup() function on a bunch of files. This makes it possible to use rfc2html with pipx/uvx as follow:

	$ wget https://www.rfc-editor.org/rfc/rfc8446.txt
	$ pipx rfc2html -v rfc8446.txt
	rfc8446.txt.html

I've tested it manually on both py3.7 (the oldest python that compiles on my machine) and py3.10 (my system python). I believe the code works with py2 as well but I can't test it. Tell me if you think it deserves a unittest.