### PR TITLE
feat: Properly link to cross-referenced RFCs

### DIFF
--- a/rfc2html.py
+++ b/rfc2html.py
@@ -210,21 +210,21 @@ def markup(text, path=".", script="", extra="", name=None):
         # section x of rfc y markup (unlinked) - mark RFC as processed with special marker
         # Use more restrictive pattern to avoid matching across sentences
         # Pattern for same-line references (don't match newlines)
-        text = re.sub(r"(?i)(section)\s+(\d+(\.\d+)*)([^.]*?)[ \t](of|in)[ \t]+(%s[- ]?)(\d+)" % n,
+        text = re.sub(r"(?i)(section)\s+(\d+(\.\d+)*)([^.\n]*?)[ \t](of|in)[ \t]+(%s[- ]?)(\d+)" % n,
             r'<a href="%s?%s%s=\g<7>#section-\g<2>">\g<1>&nbsp;\g<2>\g<4> \g<5> \g<6>%s\g<7>%s</a>' % (script, extra, n, CROSSREF_START_TAG, CROSSREF_END_TAG), text)
         # Pattern for when "of/in RFC" spans lines (preserve the newline)
-        text = re.sub(r"(?i)(section)\s+(\d+(\.\d+)*)([^.]*?)[ \t](of|in)\n([ \t]+)(%s[- ]?)(\d+)" % n,
+        text = re.sub(r"(?i)(section)\s+(\d+(\.\d+)*)([^.\n]*?)[ \t](of|in)\n([ \t]+)(%s[- ]?)(\d+)" % n,
             r'<a href="%s?%s%s=\g<8>#section-\g<2>">\g<1>&nbsp;\g<2>\g<4> \g<5>\n\g<6>\g<7>%s\g<8>%s</a>' % (script, extra, n, CROSSREF_START_TAG, CROSSREF_END_TAG), text)
-        text = re.sub(r"(?i)(section)\n(\s+)(\d+(\.\d+)*)([^.]*?)\s(of|in)\s+(%s[- ]?)(\d+)" % n,
+        text = re.sub(r"(?i)(section)\n(\s+)(\d+(\.\d+)*)([^.\n]*?)\s(of|in)\s+(%s[- ]?)(\d+)" % n,
             r'<a href="%s?%s%s=\g<8>#section-\g<3>">\g<1></a>\n\g<2><a href="%s?%s%s=\g<8>#section-\g<3>">\g<3>\g<5> \g<6> \g<7>%s\g<8>%s</a>' % (script, extra, n, script, extra, n, CROSSREF_START_TAG, CROSSREF_END_TAG), text)
         # appendix x of rfc y markup (unlinked)
         # Pattern for same-line references (don't match newlines)
-        text = re.sub(r"(?i)(appendix)\s+([A-Z](\.\d+)*)([^.]*?)[ \t](of|in)[ \t]+(%s[- ]?)(\d+)" % n,
+        text = re.sub(r"(?i)(appendix)\s+([A-Z](\.\d+)*)([^.\n]*?)[ \t](of|in)[ \t]+(%s[- ]?)(\d+)" % n,
             r'<a href="%s?%s%s=\g<7>#appendix-\g<2>">\g<1>&nbsp;\g<2>\g<4> \g<5> \g<6>%s\g<7>%s</a>' % (script, extra, n, CROSSREF_START_TAG, CROSSREF_END_TAG), text)
         # Pattern for when "of/in RFC" spans lines (preserve the newline)
-        text = re.sub(r"(?i)(appendix)\s+([A-Z](\.\d+)*)([^.]*?)[ \t](of|in)\n([ \t]+)(%s[- ]?)(\d+)" % n,
+        text = re.sub(r"(?i)(appendix)\s+([A-Z](\.\d+)*)([^.\n]*?)[ \t](of|in)\n([ \t]+)(%s[- ]?)(\d+)" % n,
             r'<a href="%s?%s%s=\g<8>#appendix-\g<2>">\g<1>&nbsp;\g<2>\g<4> \g<5>\n\g<6>\g<7>%s\g<8>%s</a>' % (script, extra, n, CROSSREF_START_TAG, CROSSREF_END_TAG), text)
-        text = re.sub(r"(?i)(appendix)\n(\s+)([A-Z](\.\d+)*)([^.]*?)\s(of|in)\s+(%s[- ]?)(\d+)" % n,
+        text = re.sub(r"(?i)(appendix)\n(\s+)([A-Z](\.\d+)*)([^.\n]*?)\s(of|in)\s+(%s[- ]?)(\d+)" % n,
             r'<a href="%s?%s%s=\g<8>#appendix-\g<3>">\g<1></a>\n\g<2><a href="%s?%s%s=\g<8>#appendix-\g<3>">\g<3>\g<5> \g<6> \g<7>%s\g<8>%s</a>' % (script, extra, n, script, extra, n, CROSSREF_START_TAG, CROSSREF_END_TAG), text)
 
     # rfc markup

--- a/tests.py
+++ b/tests.py
@@ -37,6 +37,63 @@ class MarkupTestCase(TestCase):
                 open_tag='<a href="./draft-ietf-some-name-00">',
             ))
 
+    def test_cross_rfc_section_simple(self):
+        html = markup('Section 2.4 of RFC 2595')
+        self.assertEqual(html, '<pre><a href="./rfc2595#section-2.4">Section&nbsp;2.4 of RFC 2595</a></pre>')
+
+    def test_cross_rfc_appendix_with_description(self):
+        html = markup('Appendix B (Examples) of RFC 5678')
+        self.assertEqual(html, '<pre><a href="./rfc5678#appendix-B">Appendix&nbsp;B (Examples) of RFC 5678</a></pre>')
+
+    def test_mixed_same_and_cross_rfc_sections(self):
+        html = markup('See Section 2.1 for details, but also Section 2.4 of RFC 2595 for comparison.')
+        expected = ('<pre>See <a href="#section-2.1">Section 2.1</a> for details, '
+                   'but also <a href="./rfc2595#section-2.4">Section&nbsp;2.4 of RFC 2595</a> for comparison.</pre>')
+        self.assertEqual(html, expected)
+
+    def test_cross_bcp_section(self):
+        html = markup('Section 3 of BCP 14')
+        self.assertEqual(html, '<pre><a href="./bcp14#section-3">Section&nbsp;3 of BCP 14</a></pre>')
+
+    def test_cross_std_section(self):
+        html = markup('Section 1.2 of STD 1')
+        self.assertEqual(html, '<pre><a href="./std1#section-1.2">Section&nbsp;1.2 of STD 1</a></pre>')
+
+    def test_rfc7817_abstract_example(self):
+        text = ('It replaces Section 2.4 (Server Identity Check) of RFC 2595 and updates '
+                'Section 4.1 (Processing After the STARTTLS Command) of RFC 3207, '
+                'Section 11.1 (STARTTLS Security Considerations) of RFC 3501, and '
+                'Section 2.2.1 (Server Identity Check) of RFC 5804.')
+        html = markup(text)
+
+        # Check that all cross-RFC section references are correctly linked
+        self.assertIn('href="./rfc2595#section-2.4"', html)
+        self.assertIn('href="./rfc3207#section-4.1"', html)
+        self.assertIn('href="./rfc3501#section-11.1"', html)
+        self.assertIn('href="./rfc5804#section-2.2.1"', html)
+
+        # Ensure no local section links for cross-RFC references
+        self.assertNotIn('href="#section-2.4"', html)
+        self.assertNotIn('href="#section-4.1"', html)
+        self.assertNotIn('href="#section-11.1"', html)
+        self.assertNotIn('href="#section-2.2.1"', html)
+
+    def test_cross_rfc_section_with_newline(self):
+        html = markup('Section 5.1 of\n   RFC 4279')
+        # The newline should be preserved within the link, and nbsp should be used between Section and number
+        self.assertIn('Section&nbsp;5.1 of\n   RFC 4279', html)
+        self.assertIn('href="./rfc4279#section-5.1"', html)
+
+    def test_rfc_section_split_across_lines(self):
+        # Test case for issue where "RFC-XXX Section\n   Y.Z" was being merged into one anchor
+        html = markup('         4.2.2.9  Initial Sequence Number Selection: RFC-793 Section\n            3.3, page 27')
+        # Should have two separate anchor tags with newline preserved
+        self.assertIn('<a href="./rfc793#section-3.3">RFC-793 Section&nbsp;</a>', html)
+        self.assertIn('<a href="#section-3.3">3.3</a>', html)
+        # Ensure the newline is preserved (line count should be 1)
+        content = html.replace('<pre>', '').replace('</pre>', '')
+        self.assertEqual(content.count('\n'), 1)
+
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
Fixes #38

Handles cross-RFC section references by identifying these *before* RFC linking, adding special markers, proceeding with normal RFC linking, and then removing the cross-RFC markers once finished.

To be honest, there are a bunch of very nasty regexes in here, so it was hard to be 100% certain that this was correct. I added a number of new test cases to `tests.py` to hopefully validate that this is working as expected.